### PR TITLE
Retry Submissions

### DIFF
--- a/src/express/handlers/jobs/minting.ts
+++ b/src/express/handlers/jobs/minting.ts
@@ -107,11 +107,11 @@ const mintPaidSessions = async (req: express.Request, res: express.Response) => 
     });
   } catch (e) {
     // Log the failed transaction submission (will try again on next round).
-    await PaidSessions.updateSessionStatuses('', sanitizedSessions, 'pending');
     Logger.log({ message: `Failed to mint batch: ${JSON.stringify(e)}, re-trying next time. Job details: ${JSON.stringify({
       refundableSessions,
       sanitizedSessions
     })}`, event: 'mintPaidSessionsHandler.mintHandlesAndSend.error', category: LogCategory.ERROR });
+    await PaidSessions.updateSessionStatuses('', sanitizedSessions, 'pending');
     return res.status(500).json({
       error: true,
       message: 'Transaction submission failed.'

--- a/src/express/handlers/jobs/minting.ts
+++ b/src/express/handlers/jobs/minting.ts
@@ -108,7 +108,10 @@ const mintPaidSessions = async (req: express.Request, res: express.Response) => 
       await PaidSessions.updateSessionStatuses(txId, sanitizedSessions, 'submitted');
     }
   } catch (e) {
-    Logger.log({ message: `Failed to mint batch: ${JSON.stringify(e)}. locking cron`, event: 'mintPaidSessionsHandler.mintHandlesAndSend.error', category: LogCategory.NOTIFY });
+    Logger.log({ message: `Failed to mint batch: ${JSON.stringify(e)}. Locking cron. Job details: ${JSON.stringify({
+      refundableSessions,
+      sanitizedSessions
+    })}`, event: 'mintPaidSessionsHandler.mintHandlesAndSend.error', category: LogCategory.NOTIFY });
 
     // if anything goes wrong, lock the cron job and troubleshoot.
     await StateData.lockCron(CRON_JOB_LOCK_NAME);

--- a/src/helpers/graphql.ts
+++ b/src/helpers/graphql.ts
@@ -35,6 +35,16 @@ export interface GraphqlCardanoPaymentAddress {
   };
 }
 
+interface GraphqlCardanoSlotNumberResult {
+  data: {
+    cardano: {
+      tip: {
+        slotNo: number;
+      }
+    }
+  }
+}
+
 interface GraphqlCardanoPaymentAddressesResult {
   data: {
     paymentAddresses: GraphqlCardanoPaymentAddress[];
@@ -374,3 +384,38 @@ export const lookupLocation = async (
 
   return assets;
 };
+
+export const getCurrentSlotNumberFromTip = async (): Promise<number> => {
+  const url = getGraphqlEndpoint();
+  const res: GraphqlCardanoSlotNumberResult = await fetch(url, {
+    method: 'POST',
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `
+        query {
+          cardano {
+            tip {
+              slotNo
+            }
+          }
+        }
+      `,
+    })
+  }).then(res => res.json())
+
+  if (!res?.data) {
+    throw new Error('Unable to query current slot number.');
+  }
+
+  const {
+    cardano: {
+      tip: {
+        slotNo
+      }
+    }
+  } = res.data;
+
+  return slotNo;
+}

--- a/src/helpers/wallet/index.ts
+++ b/src/helpers/wallet/index.ts
@@ -1,21 +1,11 @@
-import * as wallet from "cardano-wallet-js";
-
-import {
-  getPolicyPrivateKey,
-  getMintingWalletSeedPhrase,
-  getPolicyId
-} from "../constants";
 import {
   GraphqlCardanoPaymentAddress,
-  lookupReturnAddresses,
 } from "../graphql";
-import { getIPFSImage } from "../image";
-import { getMintWalletServer, getWalletServer, NewAddress } from "./cardano";
+import { getWalletServer, NewAddress } from "./cardano";
 import { WalletAddresses } from "../../models/firestore/collections/WalletAddresses";
-import { ReservedHandles } from "../../models/firestore/collections/ReservedHandles";
 import { PaidSession } from "../../models/PaidSession";
-import { LogCategory, Logger } from "../Logger";
-import { buildTransactionFromPaidSessions, generateMetadataFromPaidSessions, getAddressWalletsFromTransactions, getTransactionsFromPaidSessions } from "./minting";
+import { Logger } from "../Logger";
+import { buildTransactionFromPaidSessions } from "./minting";
 
 export const getNewAddress = async (): Promise<NewAddress | false> => {
   const newAddress = await WalletAddresses.getFirstAvailableWalletAddress();
@@ -44,13 +34,7 @@ export const getAmountsFromPaymentAddresses = (
 
 export const mintHandlesAndSend = async (sessions: PaidSession[]): Promise<string | void> => {
   const walletServer = getWalletServer();
-
-  try {
-    const signedTransaction = await buildTransactionFromPaidSessions(sessions);
-    const txId = await walletServer.submitTx(signedTransaction);
-    return txId;
-  } catch(e) {
-    Logger.log({ message: JSON.stringify(e), event: 'mintHandleAndSend.submitTx' });
-    throw new Error('Failed to submit transaction.');
-  }
+  const signedTransaction = await buildTransactionFromPaidSessions(sessions);
+  const txId = await walletServer.submitTx(signedTransaction);
+  return txId;
 };

--- a/src/helpers/wallet/index.ts
+++ b/src/helpers/wallet/index.ts
@@ -4,7 +4,7 @@ import {
 import { getWalletServer, NewAddress } from "./cardano";
 import { WalletAddresses } from "../../models/firestore/collections/WalletAddresses";
 import { PaidSession } from "../../models/PaidSession";
-import { Logger } from "../Logger";
+import { LogCategory, Logger } from "../Logger";
 import { buildTransactionFromPaidSessions } from "./minting";
 
 export const getNewAddress = async (): Promise<NewAddress | false> => {
@@ -32,7 +32,7 @@ export const getAmountsFromPaymentAddresses = (
   return totalBalances;
 };
 
-export const mintHandlesAndSend = async (sessions: PaidSession[]): Promise<string | void> => {
+export const mintHandlesAndSend = async (sessions: PaidSession[]): Promise<string> => {
   const walletServer = getWalletServer();
   const signedTransaction = await buildTransactionFromPaidSessions(sessions);
   const txId = await walletServer.submitTx(signedTransaction);

--- a/src/models/firestore/collections/PaidSessions.ts
+++ b/src/models/firestore/collections/PaidSessions.ts
@@ -1,4 +1,5 @@
 import * as admin from "firebase-admin";
+import { getCurrentSlotNumberFromTip } from '../../../helpers/graphql';
 import { LogCategory, Logger } from "../../../helpers/Logger";
 import { asyncForEach, chunk, delay } from "../../../helpers/utils";
 import { PaidSession, PaidSessionStatusType } from "../../PaidSession";
@@ -94,6 +95,7 @@ export class PaidSessions {
     }
 
     static async updateSessionStatuses(txId: string, sanitizedSessions: PaidSession[], statusType: PaidSessionStatusType): Promise<boolean[]> {
+        const currentSlotNumber = await getCurrentSlotNumberFromTip();
         return Promise.all(sanitizedSessions.map(async session => {
             return admin.firestore().runTransaction(async t => {
                 const ref = admin.firestore().collection(PaidSessions.collectionName).doc(session.id as string);

--- a/src/models/firestore/collections/PaidSessions.ts
+++ b/src/models/firestore/collections/PaidSessions.ts
@@ -95,7 +95,8 @@ export class PaidSessions {
     }
 
     static async updateSessionStatuses(txId: string, sanitizedSessions: PaidSession[], statusType: PaidSessionStatusType): Promise<boolean[]> {
-        const currentSlotNumber = await getCurrentSlotNumberFromTip();
+        // const currentSlotNumber = await getCurrentSlotNumberFromTip();
+        // console.log(currentSlotNumber);
         return Promise.all(sanitizedSessions.map(async session => {
             return admin.firestore().runTransaction(async t => {
                 const ref = admin.firestore().collection(PaidSessions.collectionName).doc(session.id as string);

--- a/src/scripts/updatePaidSessionStatusTests.ts
+++ b/src/scripts/updatePaidSessionStatusTests.ts
@@ -1,6 +1,7 @@
 import { Firebase } from "../helpers/firebase";
 import { PaidSessions } from "../models/firestore/collections/PaidSessions";
-
+import { config } from 'dotenv';
+config();
 
 const run = async () => {
     await Firebase.init();


### PR DESCRIPTION
The expected logic:

1. Generated Handle metadata.
2. Submit transaction to wallet server.
3. Get a txId in response, move to confirmation queue.
4. If anything throws an error during this process, then it never made it to the wallet server (therefore never submitted to the chain). This update puts those failed Handles back into the `pending` queue for minting on the next cron run. There's no risk to double minting here because the chain never received any data.

TODO: During the minting confirmation phase (after having received a valid txID, if the txID is not found after the length of the tx ttl (12000 slots), move back to pending and at no point before then).